### PR TITLE
Use the current docker download URL for static binaries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 RUN apk add --no-cache bash curl git openssh-client
 
 ENV VERSION "17.03.1-ce"
-RUN curl -L -o /tmp/docker-$VERSION.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VERSION.tgz \
+RUN curl -L -o /tmp/docker-$VERSION.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VERSION.tgz \
     && tar -xz -C /tmp -f /tmp/docker-$VERSION.tgz \
     && mv /tmp/docker/docker /usr/bin \
     && rm -rf /tmp/docker-$VERSION /tmp/docker


### PR DESCRIPTION
It appears that Docker has moved the static binary download location.

I have been able to build (and then run) the image produced with this new Dockerfile.